### PR TITLE
LastModifiedTime compare with .Equal instead of operator

### DIFF
--- a/upload/metadata/metaData.go
+++ b/upload/metadata/metaData.go
@@ -134,7 +134,7 @@ func CompareMetaData(remote, local *MetaData) []error {
 				remote.FileMetaData.FileSize, local.FileMetaData.FileSize))
 	}
 
-	if remote.FileMetaData.LastModifiedTime != local.FileMetaData.LastModifiedTime {
+	if !remote.FileMetaData.LastModifiedTime.Equal(local.FileMetaData.LastModifiedTime) {
 		metadataErrors = append(metadataErrors,
 			fmt.Errorf("Last modified time of the VHD file in Azure blob storage (%v) and local VHD file (%v) does not match",
 				remote.FileMetaData.LastModifiedTime, local.FileMetaData.LastModifiedTime))


### PR DESCRIPTION
We're seeing more frequent failures when uploading, and this patch seems like it could help based on the error messages we're seeing.

```
Last modified time of the VHD file in
Azure blob storage (2019-08-12 16:38:18.823769424 +0000 UTC)
and local VHD file (2019-08-12 16:38:18.823769424 +0000 UTC) does not match
```
_(line-breaks edited for clarity)_

From https://golang.org/pkg/time/#Time
> Note that the Go == operator compares not just the time instant but also the Location and the monotonic clock reading. Therefore, Time values should not be used as map or database keys without first guaranteeing that the identical Location has been set for all values, which can be achieved through use of the UTC or Local method, and that the monotonic clock reading has been stripped by setting t = t.Round(0). In general, prefer t.Equal(u) to t == u, since t.Equal uses the most accurate comparison available and correctly handles the case when only one of its arguments has a monotonic clock reading. 