### PR TITLE
Support reading Azure storage account key from file

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ OPTIONS:
    --localvhdpath       Path to source VHD in the local machine.
    --stgaccountname     Azure storage account name.
    --stgaccountkey      Azure storage account key.
+   --stgaccountkeyfile  Path to file containing Azure storage account key.
    --containername      Name of the container holding destination page blob. (Default: vhds)
    --blobname           Name of the destination page blob.
    --parallelism        Number of concurrent goroutines to be used for upload


### PR DESCRIPTION
This is useful if you want to hide the storage account key from system process list and/or shell history.
