### PR TITLE
Avoid scanning parent directories in the Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-rwildcard=$(foreach d,$(wildcard $1*),$(call rwildcard,$d/,$2) $(filter $(subst *,%,$2),$d))
+rwildcard=$(foreach d,$(filter-out ..,$(wildcard $1*)),$(call rwildcard,$d/,$2) $(filter $(subst *,%,$2),$d))
 
 .PHONY: all
 all: test azure-vhd-utils lint fmt


### PR DESCRIPTION
Without this filter present, make will recursilvely scan the parent directory for go files, running 'go build' if any are found to be new.

We want to avoid that, because the time it takes can be considerable if the parent directory contains a lot of other files. 